### PR TITLE
fix: fix localstorage problem, now prevent clear folders on refresh

### DIFF
--- a/assets/scripts/handle-time.js
+++ b/assets/scripts/handle-time.js
@@ -15,6 +15,5 @@ setInterval(() => {
     datePlaceholder.innerHTML = date.toLocaleDateString("en-IN", {
         dateStyle:"medium"
     });
-    console.log(datePlaceholder.innerHTML)
     timePlaceholder.innerHTML = date.toLocaleTimeString("en-US", timeFormat);
 }, 1000);

--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -4,15 +4,14 @@ let count = 1;
 const rightClickMenu = document.querySelector(".right-click-menu");
 wallpaperFilesFolderSection.addEventListener("contextmenu", (event) => {
     event.preventDefault();
-    console.log(event)
     const x = event.clientX;
     const y = event.clientY;
     rightClickMenu.style.left = x + "px";
     rightClickMenu.style.top = y + "px";
     rightClickMenu.style.display = "block";
 });
-function addNewFolder() {
-    const folderName = prompt("Enter your folder name:")
+function addNewFolder(who, fname) {
+    const folderName = fname || prompt("Enter your folder name:")
     if (!folderName || folderName === " " || folderName === null) {
         alert("Please enter valid folder name!");
         return;
@@ -33,9 +32,12 @@ function addNewFolder() {
 
     const nameOfFolder = document.createElement("p");
     nameOfFolder.innerHTML = folderName;
+    // handling localStorage
+    who === "new" ? localStorage.setItem(`folder${count}`, folderName) : null;
 
     userFolder.append(image, nameOfFolder);
     folderContainer.appendChild(userFolder);
+    count++; // count increase
 }
 wallpaperFilesFolderSection.addEventListener("click", (event) => {
     event.preventDefault();
@@ -45,7 +47,12 @@ wallpaperFilesFolderSection.addEventListener("click", (event) => {
             window.location.reload();
             break;
         case "New Folder":
-            addNewFolder();
+            addNewFolder("new");
             break;
     }
 });
+// show localstorage folders
+const allFolders = Object.values(localStorage);
+allFolders.forEach((folder, index)=>{
+    addNewFolder("already", folder)
+})


### PR DESCRIPTION
This PR , fix the folder storage problem.

- folder can't automatically gone while refreshing
- folder-name stored on localstorage

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/1990ad34-d041-4404-9c7a-5a39a6be35f9" />
